### PR TITLE
Fix $allowed_actions visitbility

### DIFF
--- a/code/formfields/WorkflowField.php
+++ b/code/formfields/WorkflowField.php
@@ -7,7 +7,7 @@
  */
 class WorkflowField extends FormField {
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'action',
 		'transition',
 		'sort'

--- a/code/formfields/WorkflowFieldActionController.php
+++ b/code/formfields/WorkflowFieldActionController.php
@@ -6,12 +6,12 @@
  */
 class WorkflowFieldActionController extends RequestHandler {
 
-	public static $url_handlers = array(
+	private static $url_handlers = array(
 		'new/$Class' => 'handleAdd',
 		'item/$ID'   => 'handleItem'
 	);
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'handleAdd',
 		'handleItem'
 	);

--- a/code/formfields/WorkflowFieldItemController.php
+++ b/code/formfields/WorkflowFieldItemController.php
@@ -6,7 +6,7 @@
  */
 class WorkflowFieldItemController extends Controller {
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index',
 		'edit',
 		'delete',

--- a/code/formfields/WorkflowFieldTransitionController.php
+++ b/code/formfields/WorkflowFieldTransitionController.php
@@ -6,12 +6,12 @@
  */
 class WorkflowFieldTransitionController extends RequestHandler {
 
-	public static $url_handlers = array(
+	private static $url_handlers = array(
 		'new/$ParentID!' => 'handleAdd',
 		'item/$ID!'      => 'handleItem'
 	);
 
-	public static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'handleAdd',
 		'handleItem'
 	);


### PR DESCRIPTION
Create, read, update and delete on workflow actions and transitions no longer return 403 forbidden status error codes.