### PR TITLE
Enabling autoload for class_exists() check

### DIFF
--- a/code/jobs/WorkflowPublishTargetJob.php
+++ b/code/jobs/WorkflowPublishTargetJob.php
@@ -1,7 +1,7 @@
 <?php
 
 // Prevent failure if queuedjobs module isn't installed.
-if (!class_exists('AbstractQueuedJob', false)) {
+if (!class_exists('AbstractQueuedJob')) {
     return;
 }
 


### PR DESCRIPTION
Enable autoload so WorkflowPublishTargetJob won't return "class not found"