### PR TITLE
Fix item links for pending/submitted items in workflow

### DIFF
--- a/code/admin/AdvancedWorkflowAdmin.php
+++ b/code/admin/AdvancedWorkflowAdmin.php
@@ -238,7 +238,7 @@ class AdvancedWorkflowAdmin extends ModelAdmin {
 			$instance->setField('Title',$target->getField('Title'));
 			$instance->setField('LastEdited',$target->getField('LastEdited'));
 			if (method_exists($target, 'CMSEditLink')) {
-				$instance->setField('ObjectRecordLink', Controller::join_links(Director::absoluteBaseURL(), $target->CMSEditLink()));
+				$instance->setField('ObjectRecordLink', $target->CMSEditLink());
 			}
 
 			$list->push($instance);


### PR DESCRIPTION
I had "http://BASE_URL/http://BASE_URL/page/path" as the link instead of "http://BASE_URL/page/path" as expected