### PR TITLE
Show newest entries at the top of the workflow logs

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -50,7 +50,7 @@ class WorkflowInstance extends DataObject {
 	);
 
     private static $default_sort = array(
-        'Created' => 'desc'
+        '"Created"' => 'DESC'
     );
 
 	/**

--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -49,6 +49,10 @@ class WorkflowInstance extends DataObject {
 		'Created'
 	);
 
+    private static $default_sort = array(
+        'Created' => 'desc'
+    );
+
 	/**
 	 * If set to true, actions that cannot be executed by the user will not show
 	 * on the frontend (just like the backend).

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -125,7 +125,7 @@ class WorkflowApplicable extends DataExtension {
 			$config->addComponent(new GridFieldEditButton());
 			$config->addComponent(new GridFieldDetailForm());
 
-			$insts = $this->owner->WorkflowInstances();
+			$insts = $this->owner->WorkflowInstances()->sort('Created', 'desc');
 			$log   = new GridField('WorkflowLog', _t('WorkflowApplicable.WORKFLOWLOG', 'Workflow Log'), $insts, $config);
 
 			$tab->push($log);

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -125,7 +125,7 @@ class WorkflowApplicable extends DataExtension {
 			$config->addComponent(new GridFieldEditButton());
 			$config->addComponent(new GridFieldDetailForm());
 
-			$insts = $this->owner->WorkflowInstances()->sort('Created', 'desc');
+			$insts = $this->owner->WorkflowInstances();
 			$log   = new GridField('WorkflowLog', _t('WorkflowApplicable.WORKFLOWLOG', 'Workflow Log'), $insts, $config);
 
 			$tab->push($log);


### PR DESCRIPTION
Ordering workflow instances by created date descending so that the latest is at the top of the logs.