### PR TITLE
Clear workflow status on new duplicate page

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -243,6 +243,15 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 			->queueJob($job, $when ? date('Y-m-d H:i:s', $when) : null);
 	}
 
+    public function onBeforeDuplicate($original, $doWrite) {
+        $clone = $this->owner;
+
+        $clone->PublishOnDate = null;
+        $clone->UnPublishOnDate = null;
+        $clone->PublishJobID = 0;
+        $clone->UnPublishJobID = 0;
+    }
+
 	/**
 	 * {@see PublishItemWorkflowAction} for approval of requested publish dates
 	 */

--- a/tests/WorkflowEmbargoExpiryTest.php
+++ b/tests/WorkflowEmbargoExpiryTest.php
@@ -433,6 +433,29 @@ class WorkflowEmbargoExpiryTest extends SapphireTest {
 		return $definition;
 	}
 
+    public function testDuplicateRemoveEmbargoExpiry() {
+        $page = SiteTree::create();
+
+        $page->Title = 'My page';
+        $page->PublishOnDate = '2020-01-01 00:00:00';
+        $page->UnPublishOnDate = '2020-01-01 01:00:00';
+
+        // fake publish jobs
+        $page->PublishJobID = 1;
+        $page->UnPublishJobID = 2;
+        $page->write();
+
+        $dupe = $page->duplicate();
+        $this->assertNotNull($page->PublishOnDate, 'Not blank publish on date');
+        $this->assertNotNull($page->UnPublishOnDate, 'Not blank unpublish on date');
+        $this->assertNotEquals($page->PublishJobID, 0, 'Publish job ID still set');
+        $this->assertNotEquals($page->UnPublishJobID, 0, 'Unpublish job ID still set');
+        $this->assertNull($dupe->PublishOnDate, 'Blank publish on date');
+        $this->assertNull($dupe->UnPublishOnDate, 'Blank unpublish on date');
+        $this->assertEquals($dupe->PublishJobID, 0, 'Publish job ID unset');
+        $this->assertEquals($dupe->UnPublishJobID, 0, 'Unpublish job ID unset');
+    }
+
     protected function logOut()
     {
         if($member = Member::currentUser()) $member->logOut();


### PR DESCRIPTION
When a page is duplicated the embargo/expiry is not carried with it to the duplicate record.