### PR TITLE
Added descriptions for Desired Publish and Un-publish dates

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -101,11 +101,11 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 				$dt = Datetimefield::create(
 					'DesiredPublishDate',
 					_t('WorkflowEmbargoExpiryExtension.REQUESTED_PUBLISH_DATE', 'Requested publish date')
-				),
+				)->setRightTitle('To request this page to be <strong>published immediately</strong> leave the date and time fields blank'),
 				$ut = Datetimefield::create(
 					'DesiredUnPublishDate',
 					_t('WorkflowEmbargoExpiryExtension.REQUESTED_UNPUBLISH_DATE', 'Requested un-publish date')
-				),
+				)->setRightTitle('To request this page to <strong>never expire</strong> leave the date and time fields blank'),
 				Datetimefield::create(
 					'PublishOnDate',
 					_t('WorkflowEmbargoExpiryExtension.PUBLISH_ON', 'Scheduled publish date')

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -101,11 +101,15 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 				$dt = Datetimefield::create(
 					'DesiredPublishDate',
 					_t('WorkflowEmbargoExpiryExtension.REQUESTED_PUBLISH_DATE', 'Requested publish date')
-				)->setRightTitle('To request this page to be <strong>published immediately</strong> leave the date and time fields blank'),
+				)->setRightTitle(
+                    _t('WorkflowEmbargoExpiryExtension.REQUESTED_PUBLISH_DATE_RIGHT_TITLE', 'To request this page to be <strong>published immediately</strong> leave the date and time fields blank')
+                ),
 				$ut = Datetimefield::create(
 					'DesiredUnPublishDate',
 					_t('WorkflowEmbargoExpiryExtension.REQUESTED_UNPUBLISH_DATE', 'Requested un-publish date')
-				)->setRightTitle('To request this page to <strong>never expire</strong> leave the date and time fields blank'),
+				)->setRightTitle(
+                    _t('WorkflowEmbargoExpiryExtension.REQUESTED_UNPUBLISH_DATE_RIGHT_TITLE', 'To request this page to <strong>never expire</strong> leave the date and time fields blank')
+                ),
 				Datetimefield::create(
 					'PublishOnDate',
 					_t('WorkflowEmbargoExpiryExtension.PUBLISH_ON', 'Scheduled publish date')


### PR DESCRIPTION
Gives more information for assumed actions that will be taken if the Desired Publish date/time or Desired un-publish date/time fields were left blank.

According to some users, it's been very common to ask the question "what does it do when this is blank?"