### PR TITLE
Disable edit when scheduled to be published

### DIFF
--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -183,7 +183,7 @@ class WorkflowApplicable extends DataExtension {
 					);
 					$addedFirst = false;
 					foreach($definitions as $definition) {
-						if($definition->getInitialAction()) {
+						if($definition->getInitialAction() && $this->owner->canEdit()) {
 							$action = FormAction::create(
 								"startworkflow-{$definition->ID}",
 								$definition->InitialActionButtonText ? $definition->InitialActionButtonText : $definition->getInitialAction()->Title

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -14,6 +14,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		'DesiredUnPublishDate'	=> 'SS_Datetime',
 		'PublishOnDate'			=> 'SS_Datetime',
 		'UnPublishOnDate'		=> 'SS_Datetime',
+        'AllowEmbargoedEditing' => 'Boolean',
 	);
 
 	private static $has_one = array(
@@ -24,6 +25,10 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 	private static $dependencies = array(
 		'workflowService'		=> '%$WorkflowService',
 	);
+
+    private static $defaults = array(
+        'AllowEmbargoedEditing' => true
+    );
 
 	// This "config" option, might better be handled in _config
 	public static $showTimePicker = true;
@@ -364,7 +369,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
      * Add edit check for when publishing has been scheduled and if any workflow definitions want the item to be disabled.
      */
     public function canEdit($member) {
-        if (!Permission::check('EDIT_EMBARGOED_WORKFLOW')) {
+        if (!Permission::check('EDIT_EMBARGOED_WORKFLOW') && // not given global/override permission to edit
+            !$this->AllowEmbargoedEditing) { // item flagged as not editable
             $now = strtotime(DBDatetime::now()->getValue());
             $publishTime = strtotime($this->owner->PublishOnDate);
 

--- a/code/services/WorkflowService.php
+++ b/code/services/WorkflowService.php
@@ -407,26 +407,32 @@ class WorkflowService implements PermissionProvider {
 				'name' => _t('AdvancedWorkflow.DELETE_WORKFLOW', 'Delete workflow'),
 				'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
 				'help' => _t('AdvancedWorkflow.DELETE_WORKFLOW_HELP', 'Users can delete workflow definitions and active workflows'),
-				'sort' => 0
+				'sort' => 1
 			),
 			'APPLY_WORKFLOW' => array(
 				'name' => _t('AdvancedWorkflow.APPLY_WORKFLOW', 'Apply workflow'),
 				'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
 				'help' => _t('AdvancedWorkflow.APPLY_WORKFLOW_HELP', 'Users can apply workflows to items'),
-				'sort' => 0
+				'sort' => 2
 			),
 			'VIEW_ACTIVE_WORKFLOWS' => array(
 				'name'     => _t('AdvancedWorkflow.VIEWACTIVE', 'View active workflows'),
 				'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
 				'help'     => _t('AdvancedWorkflow.VIEWACTIVEHELP', 'Users can view active workflows via the workflows admin panel'),
-				'sort'     => 0
+				'sort'     => 3
 			),
 			'REASSIGN_ACTIVE_WORKFLOWS' => array(
 				'name'     => _t('AdvancedWorkflow.REASSIGNACTIVE', 'Reassign active workflows'),
 				'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
 				'help'     => _t('AdvancedWorkflow.REASSIGNACTIVEHELP', 'Users can reassign active workflows to different users and groups'),
-				'sort'     => 0
-			)
+				'sort'     => 4
+			),
+            'EDIT_EMBARGOED_WORKFLOW' => array(
+                'name'     => _t('AdvancedWorkflow.EDITEMBARGO', 'Editable embargoed item in workflow'),
+                'category' => _t('AdvancedWorkflow.ADVANCED_WORKFLOW', 'Advanced Workflow'),
+                'help'     => _t('AdvancedWorkflow.EDITEMBARGOHELP', 'Allow users to edit items that have been embargoed by a workflow'),
+                'sort'     => 5
+            ),
 		);
 	}
 


### PR DESCRIPTION
This is to prevent further changes made to the draft (which users could "Save Draft") that is embargoed, so that those changes do not bypass the approval process.

This pull request works better with https://github.com/silverstripe-australia/silverstripe-advancedworkflow/pull/267
So you'd be able to disable edit, then someone will permissions would be able to cancel the embargo to allow further editing.