### PR TITLE
Added an extension hook for canPublish

### DIFF
--- a/code/dataobjects/WorkflowDefinition.php
+++ b/code/dataobjects/WorkflowDefinition.php
@@ -376,6 +376,26 @@ class WorkflowDefinition extends DataObject {
 	}
 
     /**
+     * Determines if target can be published directly when no workflow has started yet
+     * Opens extension hook to allow an extension to determine if this is allowed as well
+     *
+     * By default returns false
+     *
+     * @param $member
+     * @param $target
+     * @return Boolean
+     */
+    public function canWorkflowPublish($member, $target)
+    {
+        $publish = $this->extendedCan('canWorkflowPublish', $member, $target);
+
+        if (is_null($publish)) {
+            return false;
+        }
+        return $publish;
+    }
+
+    /**
      *
      * @param Member $member
      * @param array $context

--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -321,11 +321,19 @@ class WorkflowApplicable extends DataExtension {
 			return $active->canPublishTarget($this->owner);
 		}
 
-		// otherwise, see if there's any workflows applied. If there are, then we shouldn't be able
-		// to directly publish
-		if ($effective = $this->workflowService->getDefinitionFor($this->owner)) {
-			return false;
-		}
+        // use definition to determine if publishing directly is allowed
+        $definition = $this->workflowService->getDefinitionFor($this->owner);
+
+        if ($definition) {
+            if (!Member::currentUserID()) {
+                return false;
+            }
+            $member = Member::currentUser();
+
+            $canPublish = $definition->canWorkflowPublish($member, $this->owner);
+
+            return $canPublish;
+        }
 	}
 
 	/**


### PR DESCRIPTION
Retains previous behaviour, returns false by default, given that no extension was utilising this hook.

This change provides better flexibility for any extensions that may want to adjust the publishing behaviour rather than the default.