### PR TITLE
Prevent canPublish returning value if it is null

### DIFF
--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -318,7 +318,10 @@ class WorkflowApplicable extends DataExtension {
 		}
 
 		if ($active = $this->getWorkflowInstance()) {
-			return $active->canPublishTarget($this->owner);
+			$publish = $active->canPublishTarget($this->owner);
+            if (!is_null($publish)) {
+                return $publish;
+            }
 		}
 
 		// otherwise, see if there's any workflows applied. If there are, then we shouldn't be able


### PR DESCRIPTION
This causes the permission to be "true" and temporarily show/hide fields dependent on that permission, until the user browses away or refreshes.