### PR TITLE
Embargo and Expiry logic handling

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -248,8 +248,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 
         $clone->PublishOnDate = null;
         $clone->UnPublishOnDate = null;
-        $clone->clearPublishJob();
-        $clone->clearUnPublishJob();
+        $clone->PublishJobID = 0;
+        $clone->UnPublishJobID = 0;
     }
 
 	/**

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -412,6 +412,36 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		return $required;
 	}
 
+    public function extendedRequiredFieldsEmbargoExpiry($data)
+    {
+        $response = array(
+            'fieldName'	 => 'DesiredUnPublishDate[date]',
+            'fieldField' => null,
+            'fieldMsg'	 => null,
+            'fieldValid' => true
+        );
+
+        if (isset($data['DesiredPublishDate'], $data['DesiredUnPublishDate'])) {
+            $publish = $data['DesiredPublishDate'];
+            $unpublish = $data['DesiredUnPublishDate'];
+
+            // the times are the same
+            if (strtotime($publish) == strtotime($unpublish)) {
+                $response = array_merge($response, array(
+                    'fieldMsg'	 => _t('WorkflowEmbargoExpiryExtension.INVALIDSAMEEMBARGOEXPIRY', 'The publish date and unpublish date cannot be the same.'),
+                    'fieldValid' => false
+                ));
+            } elseif (strtotime($publish) > strtotime($unpublish)) {
+                $response = array_merge($response, array(
+                    'fieldMsg'	 => _t('WorkflowEmbargoExpiryExtension.INVALIDEXPIRY', 'The unpublish date cannot be before the publish date.'),
+                    'fieldValid' => false
+                ));
+            }
+        }
+
+        return $response;
+    }
+
 	/*
 	 * Format a date according to member/user preferences
 	 *

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -428,16 +428,16 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
         );
 
         if (isset($data['DesiredPublishDate'], $data['DesiredUnPublishDate'])) {
-            $publish = $data['DesiredPublishDate'];
-            $unpublish = $data['DesiredUnPublishDate'];
+            $publish = strtotime($data['DesiredPublishDate']);
+            $unpublish = strtotime($data['DesiredUnPublishDate']);
 
             // the times are the same
-            if (strtotime($publish) == strtotime($unpublish)) {
+            if ($publish && $unpublish && $publish == $unpublish) {
                 $response = array_merge($response, array(
                     'fieldMsg'	 => _t('WorkflowEmbargoExpiryExtension.INVALIDSAMEEMBARGOEXPIRY', 'The publish date and unpublish date cannot be the same.'),
                     'fieldValid' => false
                 ));
-            } elseif (strtotime($publish) > strtotime($unpublish)) {
+            } elseif ($publish && $unpublish && $publish > $unpublish) {
                 $response = array_merge($response, array(
                     'fieldMsg'	 => _t('WorkflowEmbargoExpiryExtension.INVALIDEXPIRY', 'The unpublish date cannot be before the publish date.'),
                     'fieldValid' => false

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -300,8 +300,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		// We should have a publish job if:
 		if((!$unPublishTime || $unPublishTime > $now) // the unpublish date not set or hasn't passed
             && (
-                ($unPublishTime && $publishTime < $unPublishTime) // publish date happens before unpublish date
-                || ($publishTime < $now) // publish date not set or has passed (so immediately)
+                ($publishTime < $now) // publish date not set or has passed (so immediately)
+                || ($unPublishTime && $publishTime < $unPublishTime) // publish date happens before unpublish date
             )
 		) {
 			// Trigger time immediately if passed
@@ -314,7 +314,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		if($unPublishTime // we have a unpublish date
             && (
                 ($unPublishTime < $now) // unpublish has passed
-                || ($publishTime <= $unPublishTime) // publish date is before or equal to unpublish date
+                || ($publishTime < $unPublishTime) // publish date is before to unpublish date
             )
         ) {
 			// Trigger time immediately if passed

--- a/tests/WorkflowEmbargoExpiry.yml
+++ b/tests/WorkflowEmbargoExpiry.yml
@@ -1,0 +1,53 @@
+WorkflowDefinition:
+  requestPublication:
+    Title: 'Request Publish'
+  approvePublication:
+    Title: 'Approve Publish'
+
+SimpleApprovalWorkflowAction:
+  requestPublication:
+    Title: 'Approve'
+    WorkflowDefID: =>WorkflowDefinition.requestPublication
+
+PublishItemWorkflowAction:
+  approvePublication:
+    Title: 'Publish'
+    WorkflowDefID: =>WorkflowDefinition.approvePublication
+
+SiteTree:
+  emptyEmbargoExpiry:
+    Title: 'Empty embargo and expiry'
+  pastEmbargo:
+    Title: 'Embargo in the past'
+    DesiredPublishDate: 2013-01-15
+  pastExpiry:
+    Title: 'Expiry in the past'
+    DesiredUnPublishDate: 2013-03-15
+  pastEmbargoExpiry:
+    Title: 'Embargo and expiry in the past'
+    DesiredPublishDate: 2013-01-15
+    DesiredUnPublishDate: 2013-03-15
+  pastEmbargoFutureExpiry:
+    Title: 'Embargo in the past and expiry in the future'
+    DesiredPublishDate: 2013-01-15
+    DesiredUnPublishDate: 2015-03-15
+  futureEmbargoExpiry:
+    Title: 'Embargo and expiry in the future'
+    DesiredPublishDate: 2015-01-15
+    DesiredUnPublishDate: 2015-03-15
+  pastEmbargoAfterExpiry:
+    Title: 'Embargo after expiry in the past'
+    DesiredPublishDate: 2013-03-15
+    DesiredUnPublishDate: 2013-01-15
+  futureEmbargoAfterExpiry:
+    Title: 'Embargo after expiry in the future'
+    DesiredPublishDate: 2015-03-15
+    DesiredUnPublishDate: 2015-01-15
+  pastSameEmbargoExpiry:
+    Title: 'Embargo and expiry are the same in the past'
+    DesiredPublishDate: 2013-01-15
+    DesiredUnPublishDate: 2013-01-15
+  futureSameEmbargoExpiry:
+    Title: 'Embargo and expiry are the same in the future'
+    DesiredPublishDate: 2015-01-15
+    DesiredUnPublishDate: 2015-01-15

--- a/tests/WorkflowEmbargoExpiryTest.php
+++ b/tests/WorkflowEmbargoExpiryTest.php
@@ -3,12 +3,15 @@
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Member;
+use SilverStripe\ORM\Versioning\Versioned;
 
 /**
  * @author marcus@silverstripe.com.au
  * @license BSD License http://silverstripe.org/bsd-license/
  */
 class WorkflowEmbargoExpiryTest extends SapphireTest {
+
+    public static $fixture_file = 'advancedworkflow/tests/WorkflowEmbargoExpiry.yml';
 
 	public function setUp()
     {
@@ -56,245 +59,264 @@ class WorkflowEmbargoExpiryTest extends SapphireTest {
 		parent::__construct();
 	}
 
-	public function testFutureDatesJobs()
-    {
-        $page = new SiteTree();
+	/**
+	 * Start a workflow for a page,
+	 * this will set it into a state where a workflow is currently being processes
+	 *
+	 * @param DataObject $obj
+	 * @return DataObject
+	 */
+	private function startWorkflow($obj)
+	{
+		$workflow = $this->objFromFixture('WorkflowDefinition', 'requestPublication');
+		$obj->WorkflowDefinitionID = $workflow->ID;
+		$obj->write();
 
-		$page->PublishOnDate = '2020-01-01 00:00:00';
-		$page->UnPublishOnDate = '2020-01-01 01:00:00';
-
-		// Two writes are necessary for this to work on new objects
-		$page->write();
-		$page->write();
-
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-        $now = strtotime(DBDatetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
+		$svc = singleton('WorkflowService');
+		$svc->startWorkflow($obj, $obj->WorkflowDefinitionID);
+		return $obj;
 	}
 
+	/**
+	 * Start and finish a workflow which will publish the page immediately basically.
+	 *
+	 * @param DataObject $obj
+	 * @return DataObject
+	 */
+	private function finishWorkflow($obj)
+	{
+		$workflow = $this->objFromFixture('WorkflowDefinition', 'approvePublication');
+		$obj->WorkflowDefinitionID = $workflow->ID;
+		$obj->write();
+
+		$svc = singleton('WorkflowService');
+		$svc->startWorkflow($obj, $obj->WorkflowDefinitionID);
+
+		$obj = DataObject::get_by_id($obj->ClassName, $obj->ID);
+		return $obj;
+	}
+
+    /**
+     * Retrieves the live version for an object
+     *
+     * @param DataObject $obj
+     * @return DataObject
+     */
+    private function getLive($obj)
+    {
+        $oldMode = Versioned::get_reading_mode();
+        Versioned::set_reading_mode(Versioned::LIVE);
+        $live = DataObject::get_by_id($obj->ClassName, $obj->ID);
+        Versioned::set_reading_mode($oldMode);
+
+        return $live;
+    }
+
+    /**
+     * Test when embargo and expiry are both empty.
+     *
+     * No jobs should be created, but page is published by the workflow action.
+     */
+    public function testEmptyEmbargoExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'emptyEmbargoExpiry');
+        $page->Content = 'Content to go live';
+
+        $live = $this->getLive($page);
+
+        $this->assertEmpty($live->Content);
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+
+        $page = $this->finishWorkflow($page);
+
+        $live = $this->getLive($page);
+
+        $this->assertNotEmpty($live->Content);
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+    }
+
+    /**
+     * Test for embargo in the past
+     *
+     * Creates a publish job which is queued for immediately
+     */
+    public function testPastEmbargo()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastEmbargo');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertNotEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+
+        $publish = strtotime($page->PublishJob()->StartAfter);
+
+        $this->assertFalse($publish);
+    }
+
+    /**
+     * Test for expiry in the past
+     *
+     * Creates an unpublish job which is queued for immediately
+     */
+    public function testPastExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertNotEquals(0, $page->UnPublishJobID);
+
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertFalse($unpublish);
+    }
+
+    /**
+     * Test for embargo and expiry in the past
+     *
+     * Creates an unpublish job which is queued for immediately
+     */
+    public function testPastEmbargoExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastEmbargoExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertNotEquals(0, $page->UnPublishJobID);
+
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertFalse($unpublish);
+    }
+
+    /**
+     * Test for embargo in the past and expiry in the future
+     *
+     * Creates a publish job which is queued for immediately and an unpublish job which is queued for later
+     */
+    public function testPastEmbargoFutureExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastEmbargoFutureExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertNotEquals(0, $page->PublishJobID);
+        $this->assertNotEquals(0, $page->UnPublishJobID);
+
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertFalse($publish);
+        $this->assertNotFalse($unpublish);
+    }
+
+    /**
+     * Test for embargo and expiry in the future
+     *
+     * Creates a publish and unpublish job which are queued for immediately
+     */
+    public function testFutureEmbargoExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'futureEmbargoExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertNotEquals(0, $page->PublishJobID);
+        $this->assertNotEquals(0, $page->UnPublishJobID);
+
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertNotFalse($publish);
+        $this->assertNotFalse($unpublish);
+    }
+
+    /**
+     * Test for embargo after expiry in the past
+     *
+     * No jobs should be created, invalid option
+     */
+    public function testPastEmbargoAfterExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastEmbargoAfterExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+    }
+
+    /**
+     * Test for embargo after expiry in the future
+     *
+     * No jobs should be created, invalid option
+     */
+    public function testFutureEmbargoAfterExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'futureEmbargoAfterExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+    }
+
+    /**
+     * Test for embargo and expiry in the past, both have the same value
+     *
+     * No jobs should be created, invalid option
+     */
+    public function testPastSameEmbargoExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'pastSameEmbargoExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+    }
+
+    /**
+     * Test for embargo and expiry in the future, both have the same value
+     *
+     * No jobs should be created, invalid option
+     */
+    public function testFutureSameEmbargoExpiry()
+    {
+        $page = $this->objFromFixture('SiteTree', 'futureSameEmbargoExpiry');
+
+        $page = $this->finishWorkflow($page);
+
+        $this->assertEquals(0, $page->PublishJobID);
+        $this->assertEquals(0, $page->UnPublishJobID);
+    }
+
+    /**
+     * When an item is queued for publishing or unpublishing and new dates are entered
+     *
+     * The existing queued jobs should be cleared
+     */
 	public function testDesiredRemovesJobs()
     {
-        $page = new SiteTree();
+        $page = $this->objFromFixture('SiteTree', 'futureEmbargoExpiry');
 
-		$page->PublishOnDate = '2020-01-01 00:00:00';
-		$page->UnPublishOnDate = '2020-01-01 01:00:00';
+        $page = $this->finishWorkflow($page);
 
-		// Two writes are necessary for this to work on new objects
-		$page->write();
-		$page->write();
-
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-        $now = strtotime(DBDatetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
+		$this->assertNotEquals(0, $page->PublishJobID);
+		$this->assertNotEquals(0, $page->UnPublishJobID);
 
 		$page->DesiredPublishDate = '2020-02-01 00:00:00';
 		$page->DesiredUnPublishDate = '2020-02-01 02:00:00';
 
 		$page->write();
 
-		$this->assertTrue($page->PublishJobID == 0);
-		$this->assertTrue($page->UnPublishJobID == 0);
-	}
-
-	public function testPublishActionWithFutureDates()
-	{
-		$action = new PublishItemWorkflowAction();
-		$instance = new WorkflowInstance();
-
-        $page = new SiteTree();
-		$page->Title = 'stuff';
-		$page->DesiredPublishDate = '2020-02-01 00:00:00';
-		$page->DesiredUnPublishDate = '2020-02-01 02:00:00';
-
-		$page->write();
-
-		$instance->TargetClass = $page->ClassName;
-		$instance->TargetID = $page->ID;
-
-		$action->execute($instance);
-
-        $page = DataObject::get_by_id('SiteTree', $page->ID);
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-        $now = strtotime(DBDatetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
-	}
-
-	/**
-	 * Test that a page with a past publish date creates the correct jobs
-	 */
-	public function testPastPublishThenUnpublish()
-    {
-        $page = new SiteTree();
-		$page->Title = 'My Page';
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past publish date
-		$page->PublishOnDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// We should still have a job to publish this page, but not unpublish
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
-
-		// Now add an expiry date in the past, but after the current publish job,
-		// and ensure that this correctly overrides the open publish request
-		$page->UnPublishOnDate = '2010-01-02 00:00:00';
-		$page->write();
-
-		// Now we should have an unpublish job, but the publish job is noticably absent
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish);
-
-		// Now add an expiry date in the future, and ensure that we get the correct combination of
-		// publish and unpublish jobs
-		$page->UnPublishOnDate = '2015-01-01 12:00:00';
-		$page->write();
-
-		// Both jobs exist
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run and the unpublish for future
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($publish); // for immediate run
-        $this->assertGreaterThan(strtotime(DBDatetime::now()->getValue()), $unpublish); // for later run
-	}
-
-	/**
-	 * Test that a page with a past unpublish date creates the correct jobs
-	 */
-	public function testPastUnPublishThenPublish()
-    {
-		$page = new SiteTree();
-		$page->Title = 'My Page';
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past unpublish date
-		$page->UnPublishOnDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// We should still have a job to unpublish this page, but not publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this job is set for immediate run
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish);
-
-		// Now add an publish date in the past, but after the unpublish job,
-		// and ensure that this correctly overrides the open unpublish request
-		$page->PublishOnDate = '2010-01-02 00:00:00';
-		$page->write();
-
-		// Now we should have an publish job, but the unpublish job is noticably absent
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this publish job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
-
-		// Now add a publish date in the future, and ensure that we get the correct combination of
-		// publish and unpublish jobs
-		$page->PublishOnDate = '2015-01-01 12:00:00';
-		$page->write();
-
-		// Both jobs exist
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run and the unpublish for future
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish); // for immediate run
-        $this->assertGreaterThan(strtotime(DBDatetime::now()->getValue()), $publish); // for later run
-	}
-
-	public function testPastPublishWithWorkflowInEffect()
-	{
-		$definition = $this->createDefinition();
-
-        $page = new SiteTree();
-		$page->Title = 'My page';
-		$page->WorkflowDefinitionID = $definition->ID;
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past publish date
-		$page->DesiredPublishDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// Workflow is in effect. No jobs have been created yet as it's not approved.
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Advance the workflow so we can see what happens
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($definition, $page);
-		$instance->execute();
-
-		// execute the "publish" workflow action
-		$action = new PublishItemWorkflowAction();
-		$action->execute($instance);
-
-		// re-fetch the Page again.
-        $page = SiteTree::get()->byId($page->ID);
-
-		// We now have a PublishOnDate field set
-		$this->assertEquals('2010-01-01 00:00:00', $page->PublishOnDate);
-		$this->assertEmpty($page->DesiredPublishDate);
-
-		// Publish job has been setup
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this publish job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
+		$this->assertEquals(0, $page->PublishJobID);
+		$this->assertEquals(0, $page->UnPublishJobID);
 	}
 
     /**
@@ -433,17 +455,14 @@ class WorkflowEmbargoExpiryTest extends SapphireTest {
 		return $definition;
 	}
 
+    /**
+     * Make sure that publish and unpublish dates are not carried over to the duplicates.
+     */
     public function testDuplicateRemoveEmbargoExpiry() {
-        $page = SiteTree::create();
-
-        $page->Title = 'My page';
-        $page->PublishOnDate = '2020-01-01 00:00:00';
-        $page->UnPublishOnDate = '2020-01-01 01:00:00';
+        $page = $this->objFromFixture('SiteTree', 'futureEmbargoExpiry');
 
         // fake publish jobs
-        $page->PublishJobID = 1;
-        $page->UnPublishJobID = 2;
-        $page->write();
+        $page = $this->finishWorkflow($page);
 
         $dupe = $page->duplicate();
         $this->assertNotNull($page->PublishOnDate, 'Not blank publish on date');


### PR DESCRIPTION
This is a change in response to the discussion https://github.com/silverstripe-australia/silverstripe-advancedworkflow/issues/282
What we've had in mind was to simplify the handling of the embargo and expiry, while at the same time make it consistent in behaviour. (e.g. Embargo equals Expiry in the past and in the future were inconsistent)
Our table of truth re-iterated as below:

```
embargo before (<) expiry            |  create publish job & unpublish job
embargo after or equals (>=) expiry  |  Don't create any jobs (and add validation on request)
expiry in the past                   |  create unpublish job ONLY (remove publish job if applicable in the past as well)
embargo in the past                  |  create publish job (and unpublish job if applicable in the future)
```

Unit tests were rewritten to be a bit more clear with what scenarios were being tested.

The same assumptions were made for blank embargo and expiry dates, where a blank embargo means something in the far past (so publish immediately, unless an expiry is in the past)
and a blank expiry means something in the far future (so never unpublish)