### PR TITLE
302 defensively check $publishTime in case of loose comparison

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -302,7 +302,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 		if((!$unPublishTime && $publishTime) // the unpublish date is not set
             || (
                 $unPublishTime > $now // unpublish date has not passed
-                && $publishTime < $unPublishTime // publish date not set or happens before unpublish date
+                && ($publishTime && ($publishTime < $unPublishTime)) // publish date not set or happens before unpublish date
             )
 		) {
 			// Trigger time immediately if passed

--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -248,8 +248,8 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
 
         $clone->PublishOnDate = null;
         $clone->UnPublishOnDate = null;
-        $clone->PublishJobID = 0;
-        $clone->UnPublishJobID = 0;
+        $clone->clearPublishJob();
+        $clone->clearUnPublishJob();
     }
 
 	/**


### PR DESCRIPTION
This commit fixes the scenario when `$publishTime` is null.

**Scenario:**
- User want to publish the page immediately, and un-publish it in the future
- Desired Publish field is blank
- Desired Un-publish field has its datetime set in the future
- Approve the workflow to publish

Based on the above:
1. `$this->owner->PublishOnDate` is `null`
2. `strtotime($this->owner->PublishOnDate);` would be `false`
3. `$publishTime < $unPublishTime` is the same as `false < 1446534665` which generates an unexpected result
