### PR TITLE
FIX: WorkflowApplicable::updateCMSActions()

### DIFF
--- a/code/extensions/WorkflowApplicable.php
+++ b/code/extensions/WorkflowApplicable.php
@@ -155,7 +155,9 @@ class WorkflowApplicable extends DataExtension {
 						$actions->push($menu);
 					}
 
-					$menu->push($workflowOptions);
+					if(!$actions->fieldByName('ActionMenus.WorkflowOptions')) {
+						$menu->push($workflowOptions);
+					}
 
 					$transitions = $active->CurrentAction()->getValidTransitions();
 


### PR DESCRIPTION
Prevent `ActionMenus.WorkflowOptions` from being added multiple times, if updateCMSActions() is called from other extensions
fixes #294