### PR TITLE
Add updateCMSFields extension point to WorkflowInstance getCMSFields

### DIFF
--- a/code/dataobjects/WorkflowInstance.php
+++ b/code/dataobjects/WorkflowInstance.php
@@ -106,6 +106,8 @@ class WorkflowInstance extends DataObject {
 
 		$fields->push($grid);
 
+		$this->extend('updateCMSFields', $fields);
+
 		return $fields;
 	}
 


### PR DESCRIPTION
I need to add a couple of extra fields to the edit form of `WorkflowInstance`, but I noticed that there was no extension point within `WorkflowInstance::getCMSFields()`.

Could one please be added?